### PR TITLE
📝 Add .env.example für Supabase-Setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# ===================================
+# Hosting with Mood - Environment Variables
+# ===================================
+# Kopiere diese Datei zu .env.local und fülle die Werte aus
+# cp .env.example .env.local
+
+# Supabase Configuration
+# Findest du unter: https://supabase.com/dashboard/project/YOUR_PROJECT/settings/api
+VITE_SUPABASE_URL=https://your-project-id.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-anon-key-here
+
+# ===================================
+# WICHTIG: Niemals echte Keys committen!
+# .env.local ist bereits in .gitignore
+# ===================================


### PR DESCRIPTION
# 📝 Add .env.example for Supabase Setup

## Problem
Neue Entwickler wissen nicht welche Umgebungsvariablen benötigt werden für Supabase-Integration.

## Lösung
`.env.example` mit dokumentierten Platzhaltern:
- `VITE_SUPABASE_URL`
- `VITE_SUPABASE_PUBLISHABLE_KEY`

## Setup-Anleitung
```bash
cp .env.example .env.local
# Dann Werte aus Supabase Dashboard eintragen
```

## Testing
- [x] Keine Code-Änderungen
- [x] Nur Dokumentation
- [x] Deploy-Ready

Closes #6

---
**🤖 Generated by GitHub-MCP-Agent V2.0**